### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@
 
 An MCP server that fetches package documentation from multiple language ecosystems for LLMs like Claude without requiring API keys.
 
+<a href="https://glama.ai/mcp/servers/8yfwtryuc5">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/8yfwtryuc5/badge" alt="DocsFetcher Server MCP server" />
+</a>
+
 ## ✨ Features
 
 - 🌐 Supports multiple programming languages (JavaScript, Python, Java, .NET, Ruby, PHP, Rust, Go, Swift)
@@ -138,7 +142,3 @@ PORT=8080 npm start
 ## 📄 License
 
 MIT
-
-```
-
-```


### PR DESCRIPTION
This PR adds a badge for the [DocsFetcher MCP Server](https://glama.ai/mcp/servers/8yfwtryuc5) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/8yfwtryuc5">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/8yfwtryuc5/badge" alt="DocsFetcher Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.